### PR TITLE
Expose rand method on Key struct

### DIFF
--- a/src/key.rs
+++ b/src/key.rs
@@ -24,7 +24,7 @@ impl Key {
     }
 
     /// Constructs a new, random `Key`.
-    pub(super) fn rand() -> Self {
+    pub fn rand() -> Self {
         let mut ret = Key([0; KEY_LENGTH]);
         for byte in &mut ret.0 {
             *byte = rand::random::<u8>();


### PR DESCRIPTION
Exposes a method to generate `Key`s randomly.